### PR TITLE
ADD: [schema type] Record

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,19 @@ Everything from `BaseSchemaType` and ...
 | **`item`** | array item object schema | `ObjectSchema` | |
 | `allowNull?` | allow `null` as a valid value | `boolean` | |
 
+### RecordSchemaType - `OSV.record(options)` - `ObjectSchema.Types.Record`
+
+#### Options
+
+Everything from `BaseSchemaType` and ...
+
+| Option Path | Info | Type | Default |
+| --- | :---: | :---: | ---: |
+| **`values`** | key value object schema | `ObjectSchema` | |
+| `keys?` | a validator instance or an array of allowed keys | `CustomSchemaType \| StringSchemaType \| string[]` | |
+| `allowNull?` | allow `null` as a valid value | `boolean` | |
+| `allowNullValues?` | allow a key value to be `null` | `boolean` | |
+
 ### StringSchemaType - `OSV.string(options)` - `ObjectSchema.Types.String`
 
 #### Options

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import BooleanSchemaType from './schema-types/boolean.schema-type';
 import CustomSchemaType from './schema-types/custom.schema-type';
 import NumberSchemaType from './schema-types/number.schema-type';
 import OptionalSchemaType from './schema-types/optional.schema-type';
+import RecordSchemaType from './schema-types/record.schema-type';
 import StringSchemaType from './schema-types/string.schema-type';
 import UnionSchemaType from './schema-types/union.schema-type';
 import ValidationError from './validation/error.validation';
@@ -22,6 +23,7 @@ const OSV: OSVTypeRef.Exposed = {
   custom: options => ObjectSchema.validators.createCustomTypeValidator(options),
   number: options => ObjectSchema.validators.createNumberTypeValidator(options),
   optional: options => ObjectSchema.validators.createOptionalTypeValidator(options),
+  record: options => ObjectSchema.validators.createRecordTypeValidator(options),
   string: options => ObjectSchema.validators.createStringTypeValidator(options),
   union: options => ObjectSchema.validators.createUnionTypeValidator(options),
 
@@ -34,6 +36,7 @@ const OSV: OSVTypeRef.Exposed = {
     custom: CustomSchemaType.validationErrorCodes,
     number: NumberSchemaType.validationErrorCodes,
     optional: OptionalSchemaType.validationErrorCodes,
+    record: RecordSchemaType.validationErrorCodes,
     string: StringSchemaType.validationErrorCodes,
     union: UnionSchemaType.validationErrorCodes,
   },
@@ -50,6 +53,7 @@ export {
   CustomSchemaType,
   NumberSchemaType,
   OptionalSchemaType,
+  RecordSchemaType,
   StringSchemaType,
   UnionSchemaType,
 

--- a/src/schema-types/index.schema-types.ts
+++ b/src/schema-types/index.schema-types.ts
@@ -4,6 +4,7 @@ import CustomSchemaType from './custom.schema-type';
 import BooleanSchemaType from './boolean.schema-type';
 import NumberSchemaType from './number.schema-type';
 import OptionalSchemaType from './optional.schema-type';
+import RecordSchemaType from './record.schema-type';
 import StringSchemaType from './string.schema-type';
 import UnionSchemaType from './union.schema-type';
 import InternalTypeRef from '../types/internal.type-ref';
@@ -15,6 +16,7 @@ const SchemaTypes = {
   Custom: CustomSchemaType,
   Optional: OptionalSchemaType,
   Number: NumberSchemaType,
+  Record: RecordSchemaType,
   String: StringSchemaType,
   Union: UnionSchemaType,
 };
@@ -32,6 +34,8 @@ export interface CreateTypeValidators {
     .CreateTypeValidator<InternalTypeRef.SchemaTypes.Number.Options, NumberSchemaType, true>;
   createOptionalTypeValidator: InternalTypeRef.SchemaTypes
     .CreateTypeValidator<InternalTypeRef.SchemaTypes.Optional.Options, OptionalSchemaType>;
+  createRecordTypeValidator: InternalTypeRef.SchemaTypes
+    .CreateTypeValidator<InternalTypeRef.SchemaTypes.Record.Options, RecordSchemaType>;
   createStringTypeValidator: InternalTypeRef.SchemaTypes
     .CreateTypeValidator<InternalTypeRef.SchemaTypes.String.Options, StringSchemaType, true>;
   createUnionTypeValidator: InternalTypeRef.SchemaTypes
@@ -45,6 +49,7 @@ const createTypes: CreateTypeValidators = {
   createCustomTypeValidator: options => new CustomSchemaType(options),
   createNumberTypeValidator: (options = {}) => new NumberSchemaType(options),
   createOptionalTypeValidator: options => new OptionalSchemaType(options),
+  createRecordTypeValidator: options => new RecordSchemaType(options),
   createStringTypeValidator: (options = {}) => new StringSchemaType(options),
   createUnionTypeValidator: options => new UnionSchemaType(options),
 };

--- a/src/schema-types/record.schema-type.ts
+++ b/src/schema-types/record.schema-type.ts
@@ -1,0 +1,125 @@
+import BaseSchemaType from './base.schema-type';
+import InternalTypeRef from '../types/internal.type-ref';
+
+class RecordSchemaType extends BaseSchemaType<InternalTypeRef.SchemaTypes.Record.Options> {
+  public static validationErrorCodes = {
+    REQUIRED_BUT_MISSING: 'record/required-but-missing',
+    NOT_OF_TYPE: 'record/not-of-type',
+    NULL_NOT_ALLOWED: 'record/null-not-allowed',
+    INVALID_KEY: 'record/invalid-key',
+    NULL_KEY_VALUE_NOT_ALLOWED: 'record/null-key-value-not-allowed',
+  };
+
+  public constructor(options: InternalTypeRef.SchemaTypes.Record.Options) {
+    super(options);
+  }
+
+  protected _validateWithOptions = (
+    value: any,
+    data: any,
+    path: string[],
+    check: InternalTypeRef.Schema.ValidationCheckOptions,
+  ): InternalTypeRef.Validation.Result => {
+    const {
+      keys: keysValidator, values: valuesValidator, allowNull, allowNullValues,
+    } = this._options;
+
+    if (this._checkRequired(value, data) && value === undefined) {
+      return this._validateError(RecordSchemaType.validationErrorCodes.REQUIRED_BUT_MISSING, {
+        value,
+        path,
+      });
+    }
+
+    if (value !== undefined) {
+      if (allowNull && value === null) {
+        return { value };
+      }
+
+      if (!allowNull && value === null) {
+        return this._validateError(RecordSchemaType.validationErrorCodes.NULL_NOT_ALLOWED, {
+          value,
+          path,
+        });
+      }
+
+      if (typeof value !== 'object') {
+        return this._validateError(RecordSchemaType.validationErrorCodes.NOT_OF_TYPE, {
+          value,
+          path,
+        });
+      }
+
+      const keys = Object.keys(value);
+
+      let validationResult: InternalTypeRef.Validation.Result;
+
+      const result: Record<string, any> = {};
+
+      for (let i = 0; i < keys.length; i += 1) {
+        if (Array.isArray(keysValidator)) {
+          if (keysValidator.indexOf(keys[i]) === -1) {
+            return this._validateError(RecordSchemaType.validationErrorCodes.INVALID_KEY, {
+              value,
+              path: [...path, keys[i]],
+            });
+          }
+        } else if (keysValidator) {
+          validationResult = keysValidator.validate(
+            keys[i],
+            data,
+            [...path, keys[i]],
+            {},
+          );
+
+          if (validationResult.error) {
+            return this._validateError(RecordSchemaType.validationErrorCodes.INVALID_KEY, {
+              value,
+              path: [...path, keys[i]],
+            });
+          }
+        }
+
+        if (value[keys[i]] === null) {
+          if (!allowNullValues) {
+            return this._validateError(
+              RecordSchemaType.validationErrorCodes.NULL_KEY_VALUE_NOT_ALLOWED,
+              {
+                value,
+                path: [...path, keys[i]],
+              },
+            );
+          }
+
+          result[keys[i]] = null;
+        } else {
+          validationResult = valuesValidator.validateSync(value[keys[i]], { check });
+
+          if (validationResult.error) {
+            return this._validateError(validationResult.error.code, {
+              value: validationResult.error.value,
+              path: validationResult.error.path ? [
+                ...path,
+                keys[i],
+                ...validationResult.error.path.split('.'),
+              ] : [
+                ...path,
+                keys[i],
+              ],
+            });
+          }
+
+          result[keys[i]] = validationResult.value;
+        }
+      }
+
+      return {
+        value: result,
+      };
+    }
+
+    return { value };
+  };
+}
+
+export default RecordSchemaType;

--- a/src/types/classes/schema-types.classes.types.ts
+++ b/src/types/classes/schema-types.classes.types.ts
@@ -5,6 +5,7 @@ import BooleanSchemaType from '../../schema-types/boolean.schema-type';
 import CustomSchemaType from '../../schema-types/custom.schema-type';
 import NumberSchemaType from '../../schema-types/number.schema-type';
 import OptionalSchemaType from '../../schema-types/optional.schema-type';
+import RecordSchemaType from '../../schema-types/record.schema-type';
 import StringSchemaType from '../../schema-types/string.schema-type';
 import UnionSchemaType from '../../schema-types/union.schema-type';
 
@@ -15,5 +16,6 @@ export type Boolean = BooleanSchemaType;
 export type Custom = CustomSchemaType;
 export type Number = NumberSchemaType;
 export type Optional = OptionalSchemaType;
+export type Record = RecordSchemaType;
 export type String = StringSchemaType;
 export type Union = UnionSchemaType;

--- a/src/types/exposed.types.ts
+++ b/src/types/exposed.types.ts
@@ -12,6 +12,7 @@ import BooleanSchemaType from '../schema-types/boolean.schema-type';
 import CustomSchemaType from '../schema-types/custom.schema-type';
 import NumberSchemaType from '../schema-types/number.schema-type';
 import OptionalSchemaType from '../schema-types/optional.schema-type';
+import RecordSchemaType from '../schema-types/record.schema-type';
 import StringSchemaType from '../schema-types/string.schema-type';
 import UnionSchemaType from '../schema-types/union.schema-type';
 
@@ -27,6 +28,8 @@ export interface Exposed {
     .SchemaTypes.Number, true>;
   optional: SchemaTypes
     .CreateTypeValidator<SchemaTypes.Optional.Options, Classes.SchemaTypes.Optional>;
+  record: SchemaTypes
+    .CreateTypeValidator<SchemaTypes.Record.Options, Classes.SchemaTypes.Record>;
   string: SchemaTypes.CreateTypeValidator<SchemaTypes.String.Options, Classes
     .SchemaTypes.String, true>;
   union: SchemaTypes.CreateTypeValidator<SchemaTypes.Union.Options, Classes.SchemaTypes.Union>;
@@ -39,6 +42,7 @@ export interface Exposed {
     custom: typeof CustomSchemaType.validationErrorCodes;
     number: typeof NumberSchemaType.validationErrorCodes;
     optional: typeof OptionalSchemaType.validationErrorCodes;
+    record: typeof RecordSchemaType.validationErrorCodes;
     string: typeof StringSchemaType.validationErrorCodes;
     union: typeof UnionSchemaType.validationErrorCodes;
   };

--- a/src/types/schema-types/index.schema-types.types.ts
+++ b/src/types/schema-types/index.schema-types.types.ts
@@ -4,6 +4,7 @@ import * as Boolean from './boolean.schema-types.types';
 import * as Custom from './custom.schema-types.types';
 import * as Number from './number.schema-types.types';
 import * as Optional from './optional.schema-types.types';
+import * as Record from './record.schema-types.types';
 import * as String from './string.schema-types.types';
 import * as Union from './union.schema-types.types';
 import BaseSchemaType from '../../schema-types/base.schema-type';
@@ -31,6 +32,7 @@ export {
   Custom,
   Number,
   Optional,
+  Record,
   String,
   Union,
 };

--- a/src/types/schema-types/record.schema-types.types.ts
+++ b/src/types/schema-types/record.schema-types.types.ts
@@ -1,0 +1,11 @@
+import ObjectSchema from '../../schema';
+import * as Base from './base.schema-types.types';
+import CustomSchemaType from '../../schema-types/custom.schema-type';
+import StringSchemaType from '../../schema-types/string.schema-type';
+
+export interface Options<Data = any> extends Base.Options {
+  keys?: CustomSchemaType | StringSchemaType | string[];
+  values: ObjectSchema<Data>;
+  allowNull?: boolean;
+  allowNullValues?: boolean;
+}


### PR DESCRIPTION
This pr adds a new schema type to validate objects. Inspired by the Typescript type `Record<string | number, any>`.

#### Example

```ts
const schema = OSV.schema(OSV.record({
  keys: OSV.string({ required: true, regex: /^[a-z]+$/, }),
  values: OSV.string({ required: true, empty: false }),
}));

// successful

schema.validate({
  ab: 'my value ab',
  cd: 'my value cd',
});

// error - invalid key

schema.validate({
  ab: 'my value ab',
  c4: 'my value c4',
});

// error - empty string

schema.validate({
  ab: 'my value ab',
  cd: '',
});
```